### PR TITLE
fix(_config): remove trailing slash from URL and deduplicate avatar key

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ description: >-                        # used by seo meta and the atom feed
   Resolución de máquinas de sitios especializados como HackTheBox o VulnHub
 
 # fill in the protocol & hostname for your site, e.g., 'https://username.github.io'
-url: 'https://skkkajenen.com/'
+url: 'https://skkkajenen.com'
 
 github:
   username: sbellidov                 # change to your github username
@@ -86,7 +86,6 @@ theme_mode:   # [light|dark]
 img_cdn: 'https://www.skkkajenen.com/assets/img'
 
 # the avatar on sidebar, support local or CORS resources
-# avatar: '/logos/panda_hacker_300x300.png'
 avatar: '/logos/panda_hacker_300x300.png'
 
 # boolean type, the global switch for ToC in posts.


### PR DESCRIPTION
- URL 'https://skkkajenen.com/' → 'https://skkkajenen.com' to prevent Jekyll from generating double slashes in internal links
- Remove redundant commented-out avatar declaration (duplicate of active line)

https://claude.ai/code/session_01LZ2WT4uVKaGAV3Lm3UjwGb