### PR TITLE
fix: pin Ruby 3.2 in workflow to fix bundle install exit code 5

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Build site


### PR DESCRIPTION
sass-embedded 1.60.0 and bundler 2.4.7 in Gemfile.lock are not compatible with Ruby 3.3.x. Pinning to Ruby 3.2 resolves the issue.

https://claude.ai/code/session_01LZ2WT4uVKaGAV3Lm3UjwGb